### PR TITLE
Update WeFactAPI.php

### DIFF
--- a/src/Hyperized/Wefact/WeFactAPI.php
+++ b/src/Hyperized/Wefact/WeFactAPI.php
@@ -23,7 +23,7 @@ class WefactAPI {
       if(in_array($method, $this->allowed)) {
         $methodName = '_'.$method;
         if(method_exists($this, $methodName)) {
-          return call_user_func_array([$this,$methodName], [$arguments]);
+          return call_user_func_array([$this,$methodName], $arguments);
         }
       }
       else


### PR DESCRIPTION
call_user_func_array([$this,$methodName], [$arguments]); 

When $arguments is an array, this call makes $arguments an array within an array and then the calls to Wefact don't work.