### PR TITLE
Bugfix wefact.php -> Wefact.php

### DIFF
--- a/src/WefactServiceProvider.php
+++ b/src/WefactServiceProvider.php
@@ -21,7 +21,7 @@ class WefactServiceProvider extends ServiceProvider {
   public function boot()
   {
     // Configuration file
-    $configPath = __DIR__.'/config/wefact.php';
+    $configPath = __DIR__.'/config/Wefact.php';
     $this->mergeConfigFrom($configPath, 'Wefact');
     $this->publishes([
       $configPath => config_path('Wefact.php'),


### PR DESCRIPTION
Laravel returned an error because /config/wefact.php does not exists. Need to be uppercased W.

Error Output: PHP Warning:  Uncaught exception 'ErrorException' with message 'require(/home/xxxx/domains/bami.nl/public_html/vendor/hyperized/wefact/src/config/wefact.php): failed to open stream: No such file or directory  ' in /home/xxxx/domains/bami.nl/public_html/vendor/laravel/framework/src/Illuminate/Support/ServiceProvider.php:67