### PR TITLE
Return the results as TypesModels instead of Arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/support": "^5.4"
+        "illuminate/support": "^5.4",
+        "jenssegers/model": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Attachment extends Model
 {

--- a/src/Models/Attachment.php
+++ b/src/Models/Attachment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Attachment extends Model
+{
+
+}

--- a/src/Models/CreditInvoice.php
+++ b/src/Models/CreditInvoice.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CreditInvoice extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case 0:
+            default:
+                return 'Nog niet ontvangen';
+                break;
+            case 1:
+                return 'Nog niet betaald';
+                break;
+            case 2:
+                return 'Deels betaald';
+                break;
+            case 3:
+                return 'Betaald';
+                break;
+            case 8:
+                return 'Creditfactuur';
+                break;
+            case 9:
+                return 'Vervallen';
+                break;
+        }
+    }
+}

--- a/src/Models/CreditInvoice.php
+++ b/src/Models/CreditInvoice.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class CreditInvoice extends Model
 {

--- a/src/Models/Creditor.php
+++ b/src/Models/Creditor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Creditor extends Model
+{
+
+}

--- a/src/Models/Creditor.php
+++ b/src/Models/Creditor.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Creditor extends Model
 {

--- a/src/Models/Debtor.php
+++ b/src/Models/Debtor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Debtor extends Model
+{
+
+}

--- a/src/Models/Debtor.php
+++ b/src/Models/Debtor.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Debtor extends Model
 {

--- a/src/Models/Domain.php
+++ b/src/Models/Domain.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Domain extends Model
 {

--- a/src/Models/Domain.php
+++ b/src/Models/Domain.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Domain extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case -1:
+            default:
+                return 'In bestelling';
+                break;
+            case 1:
+                return 'Wachten op actie';
+                break;
+            case 3:
+                return 'Aanvragen';
+                break;
+            case 4:
+                return 'Actief';
+                break;
+            case 5:
+                return 'Verlopen';
+                break;
+            case 6:
+                return 'In behandeling';
+                break;
+            case 7:
+                return 'Fout opgetreden';
+                break;
+            case 8:
+                return 'Geannuleerd';
+                break;
+            case 9:
+                return 'Verwijderd';
+                break;
+        }
+    }
+}

--- a/src/Models/Group.php
+++ b/src/Models/Group.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Group extends Model
 {

--- a/src/Models/Group.php
+++ b/src/Models/Group.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Group extends Model
+{
+
+}

--- a/src/Models/Handle.php
+++ b/src/Models/Handle.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Handle extends Model
+{
+
+}

--- a/src/Models/Handle.php
+++ b/src/Models/Handle.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Handle extends Model
 {

--- a/src/Models/Hosting.php
+++ b/src/Models/Hosting.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Hosting extends Model
 {

--- a/src/Models/Hosting.php
+++ b/src/Models/Hosting.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Hosting extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case -1:
+            default:
+                return 'In bestelling';
+                break;
+            case 1:
+                return 'Wachten op actie';
+                break;
+            case 3:
+                return 'Aanmaken';
+                break;
+            case 4:
+                return 'Actief';
+                break;
+            case 5:
+                return 'Geblokkeerd';
+                break;
+            case 7:
+                return 'Fout opgetreden';
+                break;
+            case 9:
+                return 'Verwijderd';
+                break;
+        }
+    }
+}

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case 0:
+            default:
+                return 'Concept factuur';
+                break;
+            case 1:
+                return 'Wachtrij factuur';
+                break;
+            case 2:
+                return 'Verzonden';
+                break;
+            case 3:
+                return 'Deels betaald';
+                break;
+            case 4:
+                return 'Betaald';
+                break;
+            case 8:
+                return 'Creditfactuur';
+                break;
+            case 9:
+                return 'Vervallen';
+                break;
+        }
+    }
+}

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -2,10 +2,18 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Invoice extends Model
 {
+    /**
+     * @return mixed|string
+     */
+    public function getName()
+    {
+        return (! empty($this->CompanyName)) ? $this->CompanyName : $this->Initials.' '.$this->SurName;
+    }
+
     /**
      * @return string
      */

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Order extends Model
 {

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case 0:
+            default:
+                return 'Ontvangen';
+                break;
+            case 1:
+                return 'In behandeling';
+                break;
+            case 2:
+                return 'Cronjob fout, handmatig doorzetten';
+                break;
+            case 8:
+                return 'Behandeld';
+                break;
+            case 9:
+                return 'Geannuleerd';
+                break;
+        }
+    }
+}

--- a/src/Models/PriceQuote.php
+++ b/src/Models/PriceQuote.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class PriceQuote extends Model
 {

--- a/src/Models/PriceQuote.php
+++ b/src/Models/PriceQuote.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PriceQuote extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case 0:
+            default:
+                return 'Concept offerte';
+                break;
+            case 1:
+                return 'Wachtrij';
+                break;
+            case 2:
+                return 'Verzonden';
+                break;
+            case 3:
+                return 'Geaccepteerd';
+                break;
+            case 4:
+                return 'Factuur aangemaakt';
+                break;
+            case 8:
+                return 'Niet geaccepteerd';
+                break;
+        }
+    }
+}

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+
+}

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Product extends Model
 {

--- a/src/Models/Service.php
+++ b/src/Models/Service.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Service extends Model
 {

--- a/src/Models/Service.php
+++ b/src/Models/Service.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Service extends Model
+{
+
+}

--- a/src/Models/Ssl.php
+++ b/src/Models/Ssl.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Ssl extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case 'inorder':
+            default:
+                return 'In bestelling';
+                break;
+            case 'waiting':
+                return 'Wachten op actie';
+                break;
+            case 'inrequest':
+                return 'In aanvraag';
+                break;
+            case 'install':
+                return 'Te installeren';
+                break;
+            case 'active':
+                return 'Actief';
+                break;
+            case 'expired':
+                return 'Verlopen';
+                break;
+            case 'uninstalled':
+                return 'Gedeïnstalleerd';
+                break;
+            case 'error':
+                return 'Fout opgetreden';
+                break;
+            case 'removed':
+                return 'Verwijderd';
+                break;
+        }
+    }
+}

--- a/src/Models/Ssl.php
+++ b/src/Models/Ssl.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Ssl extends Model
 {

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Subscription extends Model
+{
+
+}

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Subscription extends Model
 {

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Ticket extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case 0:
+            default:
+                return 'Nieuw bericht';
+                break;
+            case 1:
+                return 'Open';
+                break;
+            case 2:
+                return 'In behandeling';
+                break;
+            case 3:
+                return 'Gesloten';
+                break;
+        }
+    }
+}

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -2,10 +2,18 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Ticket extends Model
 {
+    /**
+     * @return mixed|string
+     */
+    public function getName()
+    {
+        return (! empty($this->CompanyName)) ? $this->CompanyName : $this->Initials.' '.$this->SurName;
+    }
+
     /**
      * @return string
      */

--- a/src/Models/Vps.php
+++ b/src/Models/Vps.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Hyperized\Wefact\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Vps extends Model
+{
+    /**
+     * @return string
+     */
+    public function getStatusText()
+    {
+        switch($this->Status){
+            case 'inorder':
+            default:
+                return 'In bestelling';
+                break;
+            case 'waiting':
+                return 'Wachten op actie';
+                break;
+            case 'create':
+                return 'Aanmaken';
+                break;
+            case 'building':
+                return 'In behandeling';
+                break;
+            case 'active':
+                return 'Actief';
+                break;
+            case 'suspended':
+                return 'Geblokkeerd';
+                break;
+            case 'error':
+                return 'Fout opgetreden';
+                break;
+            case 'removed':
+                return 'Verwijderd';
+                break;
+        }
+    }
+}

--- a/src/Models/Vps.php
+++ b/src/Models/Vps.php
@@ -2,7 +2,7 @@
 
 namespace Hyperized\Wefact\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Jenssegers\Model\Model;
 
 class Vps extends Model
 {

--- a/src/WefactAPI.php
+++ b/src/WefactAPI.php
@@ -118,19 +118,21 @@ class WefactAPI
         } else {
             $result = json_decode($curlResp, true);
 
-            $informationKey = last(array_keys($result));
-            $typeClass = '\\Hyperized\\Wefact\Models\\'.class_basename($this);
+            if($result['action'] != 'list' || $result['currentresults'] > 0) {
+                $informationKey = last(array_keys($result));
+                $typeClass = '\\Hyperized\\Wefact\Models\\'.class_basename($this);
 
-            if($result['action'] == 'list') {
-                $result[$informationKey] = collect($result[$informationKey]);
+                if($result['action'] == 'list') {
+                    $result[$informationKey] = collect($result[$informationKey]);
 
-                foreach($result[$informationKey] as $key => $value) {
-                    $result[$informationKey][$key] = (new $typeClass)
-                        ->forceFill($value);
+                    foreach($result[$informationKey] as $key => $value) {
+                        $result[$informationKey][$key] = (new $typeClass)
+                            ->forceFill($value);
+                    }
+                } else {
+                    $result[$informationKey] = (new $typeClass)
+                        ->forceFill($result[$informationKey]);
                 }
-            } else {
-                $result[$informationKey] = (new $typeClass)
-                    ->forceFill($result[$informationKey]);
             }
         }
 

--- a/src/WefactAPI.php
+++ b/src/WefactAPI.php
@@ -117,6 +117,21 @@ class WefactAPI
             ];
         } else {
             $result = json_decode($curlResp, true);
+
+            $informationKey = last(array_keys($result));
+            $typeClass = '\\Hyperized\\Wefact\Models\\'.class_basename($this);
+
+            if($result['action'] == 'list') {
+                $result[$informationKey] = collect($result[$informationKey]);
+
+                foreach($result[$informationKey] as $key => $value) {
+                    $result[$informationKey][$key] = (new $typeClass)
+                        ->forceFill($value);
+                }
+            } else {
+                $result[$informationKey] = (new $typeClass)
+                    ->forceFill($result[$informationKey]);
+            }
         }
 
         return $result;


### PR DESCRIPTION
Currently this package returns the results as a plain array, so it's not possible to use built-in Laravel-features a-la [sum](https://laravel.com/docs/5.5/collections#method-sum), [max](https://laravel.com/docs/5.5/collections#method-max), [min](https://laravel.com/docs/5.5/collections#method-min), etc.

With this Pull Request the results will be fill'd in their own (Response)Models (_I didn't used the Types/* ones, b/c that looks more RequestTypes then ResponseTypes/Entities/Models to me_), so it's possible to use [Collection-based functions](https://laravel.com/docs/5.5/collections). It's also possible to call functions (e.g. getStatusText() instead of StatusCode with the list-call) to get the [correct meaning](https://www.wefact.nl/wefact-hosting/apiv2/variabelen-lijst/) of it.

If you have suggestions/comments for another naming of Models or something else, let me know, I can change them.

This Pull Request is also not a breaking change, the current users can use it without any problems ...